### PR TITLE
Change pkgbuilds python

### DIFF
--- a/PKGBUILD-python
+++ b/PKGBUILD-python
@@ -24,6 +24,6 @@ build() {
 package() {
   cd "$pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --optimize=1
+  python setup.py install --prefix=/usr --root="$pkgdir" --optimize=1
 }
 

--- a/PKGBUILD-python
+++ b/PKGBUILD-python
@@ -6,17 +6,19 @@ pkgver=VERSION
 pkgrel=1
 pkgdesc='Short description without using the package name itself.'
 arch=('any' OR 'x86_64' 'armv6h' 'armv7h' 'aarch64')
+groups=('blackarch' MORE_BLACKARCH_GROUPS_HERE)
 url='URL pointing to download section of package'
 license=('WHATEVER' OR 'custom:unknown')
-depends=('python')
+depends=()
 makedepends=()
-source=("")
+options=(!emptydirs)
+source=("https://foo.bar/downloads/$pkgname-$pkgver.tar.gz")
 sha512sums=('')
 
 build() {
   cd "$pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir"
+  python setup.py build
 }
 
 package() {

--- a/PKGBUILD-python-lib
+++ b/PKGBUILD-python-lib
@@ -6,13 +6,11 @@ pkgver=VERSION
 pkgrel=1
 pkgdesc='Short description without using the package name itself.'
 arch=('any' OR 'x86_64' 'armv6h' 'armv7h' 'aarch64')
-groups=('blackarch' MORE_BLACKARCH_GROUPS_HERE)
 url='URL pointing to download section of package'
 license=('WHATEVER' OR 'custom:unknown')
-depends=()
+depends=('python')
 makedepends=()
-options=(!emptydirs)
-source=("https://foo.bar/downloads/$pkgname-$pkgver.tar.gz")
+source=("")
 sha512sums=('')
 
 build() {

--- a/PKGBUILD-python-lib
+++ b/PKGBUILD-python-lib
@@ -22,6 +22,6 @@ build() {
 package() {
   cd "$pkgname-$pkgver"
 
-  python setup.py install --root="$pkgdir" --optimize=1
+  python setup.py install --prefix=/usr --root="$pkgdir" --optimize=1
 }
 


### PR DESCRIPTION
I think the python and python-lib template got mixed up.

- switch both templates
- one template installs twice, change that to build
- add --prefix flag to python install