### PR TITLE
fix deprecated option

### DIFF
--- a/PKGBUILD-ruby-gem
+++ b/PKGBUILD-ruby-gem
@@ -16,7 +16,7 @@ noextract=("$_gemname-$pkgver.gem")
 sha512sums=('')
 
 package() {
-  local _gemdir="$(ruby -rubygems -e'puts Gem.default_dir')"
+  local _gemdir="$(ruby -r rubygems -e'puts Gem.default_dir')"
 
   if [[ $CARCH == arm* ]] ; then
     gem install --ignore-dependencies --no-user-install --no-rdoc --no-ri \


### PR DESCRIPTION
fix

```
`ubygems.rb' is deprecated, and will be removed on or after 2018-12-01. Remove `-rubygems' from your command-line, or use `-r rubygems' instead                                                                                               
```