### PR TITLE
multiple changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+

--- a/PKGBUILD-generic-git
+++ b/PKGBUILD-generic-git
@@ -20,7 +20,7 @@ pkgver() {
   # use, if no version string provided neither in sources nor in git describe:
   echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
 
-  # if s tag exists, use this
+  # if tag exists, use this
   git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 

--- a/PKGBUILD-ruby-gem
+++ b/PKGBUILD-ruby-gem
@@ -13,7 +13,7 @@ license=('WHATEVER' OR 'custom:unknown')
 depends=('ruby')
 source=("https://rubygems.org/downloads/$_gemname-$pkgver.gem")
 noextract=("$_gemname-$pkgver.gem")
-b2sums=()
+sha512sums=()
 
 package() {
   local _gemdir="$(ruby -e'puts Gem.default_dir')"

--- a/PKGBUILD-ruby-git
+++ b/PKGBUILD-ruby-git
@@ -1,0 +1,46 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+_gemname=GEM_NAME
+pkgname=NAME-git
+pkgver=VERSION
+pkgrel=1
+pkgdesc='Short description without using the package name itself.'
+arch=('any' OR 'x86_64' 'armv6h' 'armv7h' 'aarch64')
+url='https://orange-cyberdefense.github.io/rabid/'
+license=('MIT')
+depends=('ruby' 'FOO' 'FOO')
+conflicts=('NAME')
+provides=('NAME')
+options=(!emptydirs)
+source=("git+https://github.com/foo/$_gemname.git")
+b2sums=('SKIP')
+
+pkgver() {
+  cd $_gemname
+
+  # use, if no version string provided neither in sources nor in git describe:
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+
+  # if tag exists, use this
+  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $_gemname
+
+  gem build foo.gemspec
+}
+
+package() {
+  cd $_gemname
+
+  local _gemdir="$(ruby -e'puts Gem.default_dir')"
+  local _release=$(gem build foo.gemspec | grep Version | cut -d' ' -f4)
+  gem install --ignore-dependencies --no-user-install --no-document -i "$pkgdir/$_gemdir" -n "$pkgdir/usr/bin" $_gemname-$_release.gem
+  rm "$pkgdir/$_gemdir/cache/$_gemname-$_release.gem"
+  find "$pkgdir/$_gemdir/extensions/" -name *.so -delete
+  rm -r "$pkgdir/$_gemdir/gems/$_gemname-$_release/test"
+  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$_release/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+

--- a/PKGBUILD-ruby-git
+++ b/PKGBUILD-ruby-git
@@ -14,7 +14,7 @@ conflicts=('NAME')
 provides=('NAME')
 options=(!emptydirs)
 source=("git+https://github.com/foo/$_gemname.git")
-b2sums=('SKIP')
+sha512sums=('SKIP')
 
 pkgver() {
   cd $_gemname

--- a/PKGBUILD-ruby-lib-gem
+++ b/PKGBUILD-ruby-lib-gem
@@ -13,7 +13,7 @@ license=('WHATEVER' OR 'custom:unknown')
 depends=('ruby')
 source=("https://rubygems.org/downloads/$_gemname-$pkgver.gem")
 noextract=("$_gemname-$pkgver.gem")
-b2sums=()
+sha512sums=()
 
 package() {
   local _gemdir="$(ruby -e'puts Gem.default_dir')"

--- a/PKGBUILD-ruby-lib-gem
+++ b/PKGBUILD-ruby-lib-gem
@@ -2,7 +2,7 @@
 # See COPYING for license details.
 
 _gemname=GEM_NAME
-pkgname=NAME
+pkgname=ruby-NAME
 pkgver=VERSION
 pkgrel=1
 pkgdesc='Short description without using the package name itself.'

--- a/PKGBUILD-ruby-lib-git
+++ b/PKGBUILD-ruby-lib-git
@@ -14,7 +14,7 @@ conflicts=('NAME')
 provides=('NAME')
 options=(!emptydirs)
 source=("git+https://github.com/foo/$_gemname.git")
-b2sums=('SKIP')
+sha512sums=('SKIP')
 
 pkgver() {
   cd $_gemname

--- a/PKGBUILD-ruby-lib-git
+++ b/PKGBUILD-ruby-lib-git
@@ -1,0 +1,46 @@
+# This file is part of BlackArch Linux ( https://www.blackarch.org/ ).
+# See COPYING for license details.
+
+_gemname=GEM_NAME
+pkgname=ruby-NAME-git
+pkgver=VERSION
+pkgrel=1
+pkgdesc='Short description without using the package name itself.'
+arch=('any' OR 'x86_64' 'armv6h' 'armv7h' 'aarch64')
+url='https://orange-cyberdefense.github.io/rabid/'
+license=('MIT')
+depends=('ruby' 'FOO' 'FOO')
+conflicts=('NAME')
+provides=('NAME')
+options=(!emptydirs)
+source=("git+https://github.com/foo/$_gemname.git")
+b2sums=('SKIP')
+
+pkgver() {
+  cd $_gemname
+
+  # use, if no version string provided neither in sources nor in git describe:
+  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
+
+  # if tag exists, use this
+  git describe --long | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+  cd $_gemname
+
+  gem build foo.gemspec
+}
+
+package() {
+  cd $_gemname
+
+  local _gemdir="$(ruby -e'puts Gem.default_dir')"
+  local _release=$(gem build foo.gemspec | grep Version | cut -d' ' -f4)
+  gem install --ignore-dependencies --no-user-install --no-document -i "$pkgdir/$_gemdir" -n "$pkgdir/usr/bin" $_gemname-$_release.gem
+  rm "$pkgdir/$_gemdir/cache/$_gemname-$_release.gem"
+  find "$pkgdir/$_gemdir/extensions/" -name *.so -delete
+  rm -r "$pkgdir/$_gemdir/gems/$_gemname-$_release/test"
+  install -D -m644 "$pkgdir/$_gemdir/gems/$_gemname-$_release/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}
+


### PR DESCRIPTION
.editorconfig: enforce some dev style in most editors
PKGBUILD-generic-git: fix a typo
PKGBUILD-ruby-gem: update
PKGBUILD-ruby-git: add
PKGBUILD-ruby-lib-gem: add
PKGBUILD-ruby-lib-git: add

Add a version for CLI tool or for lib.
Add a version from gem release and a version for bleeding edge git.

Explicitly specifying rubygems is no longer required.
In recent bundler versions `--no-document` replace `--no-rdoc --no-ri`.
No more need for a different version per architecture.
Specify the bin directory.
Remove uneeded files after potential compilation (if a native gem).