### PR TITLE
PKGBUILD-go: use build flags & no more pie

### DIFF
--- a/PKGBUILD-go
+++ b/PKGBUILD-go
@@ -10,7 +10,7 @@ groups=('blackarch' MORE_BLACKARCH_GROUPS_HERE)
 url='URL pointing to download section of package'
 license=('WHATEVER' OR 'custom:unknown')
 depends=()
-makedepends=('git' 'go-pie')
+makedepends=('git' 'go')
 source=("git+https://github.com/foo/$pkgname.git")
 sha512sums=('')
 _url='github.com/foo/bar'
@@ -35,7 +35,13 @@ build() {
 package() {
   install -dm 755 "$pkgdir/usr/bin"
 
-  GOPATH="$srcdir" go build -v $_url
+  GOPATH="$srcdir" go build \
+    -trimpath \
+    -buildmode=pie \
+    -mod=readonly \
+    -modcacherw \
+    -ldflags "-linkmode external -extldflags \"${LDFLAGS}\"" \
+    -v $_url
 
   install -Dm 755 "$srcdir/$pkgname" "$pkgdir/usr/bin/$pkgname"
   install -Dm 644 -t "$pkgdir/usr/share/doc/$pkgname/" "src/$_url/README.md"


### PR DESCRIPTION
Addresses https://github.com/BlackArch/blackarch/issues/2926

Brings this template closer to [AL Go package guidelines](https://wiki.archlinux.org/index.php/Go_package_guidelines).

**ps.** I'm confused by building in `package` stage.
Is there a good reason for it?

**pps.** [grype](https://github.com/BlackArch/blackarch/pull/2927) is an example of an updated package