### PR TITLE
predictable pypi URL

### DIFF
--- a/PKGBUILD-python
+++ b/PKGBUILD-python
@@ -11,7 +11,7 @@ url='URL pointing to download section of package'
 license=('WHATEVER' OR 'custom:unknown')
 depends=('python')
 makedepends=('python-setuptools')
-source=("")
+source=("https://files.pythonhosted.org/packages/source/{first letter of package name}/{package name}/$_pkgname-$pkgver.tar.gz")
 sha512sums=('')
 
 build() {

--- a/PKGBUILD-python-lib
+++ b/PKGBUILD-python-lib
@@ -12,7 +12,7 @@ url='URL pointing to download section of package'
 license=('WHATEVER' OR 'custom:unknown')
 makedepends=('python2-setuptools' 'python-setuptools')
 options=(!emptydirs)
-source=("https://foo.bar/downloads/$_pkgname-$pkgver.tar.gz")
+source=("https://files.pythonhosted.org/packages/source/{first letter of package name}/{package name}/$_pkgname-$pkgver.tar.gz")
 sha512sums=('')
 
 prepare() {


### PR DESCRIPTION
Taking a random example of python library: parfit (https://pypi.org/project/parfit/).

**What we should use in `source=("")`:**

- Github release or github git tag archive: https://github.com/jmcarpenter2/parfit/archive/0.191.tar.gz
- Predictable pypi link: https://files.pythonhosted.org/packages/source/p/parfit/parfit-0.220.tar.gz

**What we shouldn't use in `source=("")`:**

- Non predictable pypi link: https://files.pythonhosted.org/packages/08/60/8090b25f914c91914e8bb5c87819bfe52cead06b6d1a557f20afbe62c1ec/parfit-0.220.tar.gz (available at https://pypi.org/project/parfit/#files)

For source tarbals the structure of the pypi predictable link is:

```
https://files.pythonhosted.org/packages/source/{first letter of package name}/{package name}/$_pkgname-$pkgver.tar.gz
```

See https://github.com/pypa/warehouse/issues/1239

For wheel or other tarbals check https://github.com/pypa/warehouse/issues/1944 and https://www.python.org/dev/peps/pep-0491/#file-name-convention.