### PR TITLE
use 2 in 1 with revision fix

### DIFF
--- a/PKGBUILD-generic-git
+++ b/PKGBUILD-generic-git
@@ -15,15 +15,12 @@ source=("git+https://github.com/foo/$pkgname.git")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $pkgname
-
-  # use, if no version string provided neither in sources nor in git describe:
-  echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-
-  # if tag exists, use this
-  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  cd "$pkgname"
+  ( set -o pipefail
+    git describe --long --tags --abbrev=7 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+  )
 }
-
 prepare() {
   cd $pkgname
 

--- a/PKGBUILD-generic-git
+++ b/PKGBUILD-generic-git
@@ -21,6 +21,7 @@ pkgver() {
     printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
   )
 }
+
 prepare() {
   cd $pkgname
 

--- a/PKGBUILD-generic-git
+++ b/PKGBUILD-generic-git
@@ -18,7 +18,7 @@ pkgver() {
   cd "$pkgname"
   ( set -o pipefail
     git describe --long --tags --abbrev=7 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
-    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+    printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
   )
 }
 


### PR DESCRIPTION
fix #19, I added `--tags` to use un-annotated tags as well. @noptrix What's the impact on existing package? Should we use it only for new ones or update the existing? If i understand correctly the only problematic package are those in the case described here https://github.com/BlackArch/blackarch-pkgbuilds/issues/19#issuecomment-1477479934 that well need an epoch. Maybe https://github.com/BlackArch/blackarch/blob/master/scripts/up-git-tools need update too?