### PR TITLE
PKGBUILD-rust: added warning for lto issues.

### DIFF
--- a/PKGBUILD-rust
+++ b/PKGBUILD-rust
@@ -25,6 +25,9 @@ pkgver() {
 }
 
 build() {
+  # If building the package fails, uncomment the following line.
+  # See https://archlinux.org/todo/lto-fat-objects/ for more details.
+  #CFLAGS+=' -ffat-lto-objects'
   cd $pkgname
 
   cargo build --release --locked


### PR DESCRIPTION
Added a warning for the compiling issues related to lto.
See https://archlinux.org/todo/lto-fat-objects/ and https://gitlab.archlinux.org/archlinux/packaging/packages/pacman/-/issues/20 for more details.

Cheers!