### PR TITLE
python venv upgrade

### DIFF
--- a/python/python-standalone.install
+++ b/python/python-standalone.install
@@ -15,7 +15,12 @@ post_install() {
 }
 
 post_upgrade() {
-  post_install "$@"
+  set -e
+  cd /usr/share/NAME
+  source venv/bin/activate &&
+    pip install --isolated --root=/usr/share/NAME --prefix=venv \
+      NAME -U
+  # post_install "$@"
 }
 
 post_remove() {


### PR DESCRIPTION
@noptrix I noticed `post_install "$@"` doesn't work for upgrade, because it just runs a classic `pip install` but pip will say `Requirement already satisfied` and keep the previous version. We actually need to add `-U` to force to upgrade to the latest version even when a previous one is already installed in the current venv.

`pip install -U` is cleaner and faster than removing the venv and recreating it.